### PR TITLE
Update extension pattern for asset file hashes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export async function ignoreMissingFile(promise: Promise<void>) {
 export async function convertFileExtension(
   inputFilename: string, inputExtension: string, outputExtension: string, options: babel.TransformOptions,
 ) {
-  const outputFilename = inputFilename.replace(/\..+$/, `.${outputExtension}`);
+  const outputFilename = inputFilename.replace(/\.[^.]+$/, `.${outputExtension}`);
   const result = await dependencies.transformFile(
     inputFilename, {
       ...options,


### PR DESCRIPTION
The pattern to match extensions on input file names allows for every character. This results in files named like `bundle.a2b2c3.js` to have their file hashes removed when their extensions are changed. To preserve file hashes, this change updates the pattern to allow for every character except a period (`.`) in file extensions.